### PR TITLE
ci: use date-pinned repo for R 4.0.5 job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,8 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 4.0.5
+            cran_override: 'https://packagemanager.posit.co/cran/2025-07-10'
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2025-07-10'
           - os: ubuntu-22.04
             r: 4.1.3
           - os: ubuntu-22.04
@@ -35,12 +37,15 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
+        env:
+          RSPM: ${{ matrix.config.rspm }}
+          CRAN: ${{ matrix.config.cran_override }}
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-          upgrade: 'TRUE'
+          upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
         with:
           error-on: '"note"'


### PR DESCRIPTION
As mentioned at [gh-12](https://github.com/metrumresearchgroup/paquet/pull/12#pullrequestreview-3625111196), the R 4.0.5 job is now failing.  This PR resolves the failure by using a date-pinned URL for that job.