### PR TITLE
Release/0.2.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,4 @@
 foo
-NEWS\.md
 ^.*\.Rproj$
 ^\.Rproj\.user$
 test\.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paquet
 Type: Package
 Title: File Streams for Big Data
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R:
     c(person(given = "Kyle T", family = "Baron",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
-# paquet (development version)
+# paquet 0.2.0
 
-- Add support for parquet format locker storage via the arrow package (#11, #12).
+- Add support for parquet format locker storage via the arrow package 
+  (#11, #12).
+- Optionally set a random seed for each item in the stream (#15).
+  - Use `seed_stream()` to assign a seed to each position in the stream.
+  - Call `set_stream_seed()` on the worker to use the assigned seed.
+- `qs` file format no longer supported; add `qdata` format as a replacement 
+  via the `qs2` package (#16).
+- Add `$` extraction from file stream lists to retrieve fields as a vector 
+  or list (#18).
 
 # paquet 0.1.0
 

--- a/vignettes/file-stream.Rmd
+++ b/vignettes/file-stream.Rmd
@@ -74,6 +74,13 @@ There are three named positions
 1. `file` the stem of the output file for this replicate
 1. `x` the data payload for this replicate; in this case it is just `i`
 
+These can be extracted with the `$` operator.
+
+```{r}
+x$x
+x$file
+```
+
 The stem of the output file is named with the current replicate number (`05`) 
 and the total number of replicates in the set (`10`).  The file stem will always 
 be configured to have the format `n` of `N`; but can be customized with a 


### PR DESCRIPTION
# paquet 0.2.0

- Add support for parquet format locker storage via the arrow package 
  (#11, #12).
- Optionally set a random seed for each item in the stream (#15).
  - Use `seed_stream()` to assign a seed to each position in the stream.
  - Call `set_stream_seed()` on the worker to use the assigned seed.
- `qs` file format no longer supported; add `qdata` format as a replacement 
  via the `qs2` package (#16).
- Add `$` extraction from file stream lists to retrieve fields as a vector 
  or list (#18).
